### PR TITLE
[Fix]: both capsule caps had wrong position

### DIFF
--- a/examples/src/primitives/primitives.cpp
+++ b/examples/src/primitives/primitives.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
             ob = spheres.back();
             break;
           case 2:
-            capsules.push_back(world.addCapsule(0.5, 1., 1));
+            capsules.push_back(world.addCapsule(0.25, 0.5, 1));
             vis->createGraphicalObject(capsules.back(), "capsules" + number, "blue");
             ob = capsules.back();
             break;

--- a/src/OgreVis.cpp
+++ b/src/OgreVis.cpp
@@ -667,14 +667,14 @@ std::vector<GraphicObject> *OgreVis::createGraphicalObject(raisim::Capsule *caps
                                                   "sphereMesh",
                                                   material,
                                                   {rad, rad, rad},
-                                                  {0, 0, 0.5},
+                                                  {0, 0, 0.5 * h},
                                                   rot,
                                                   0),
                       createSingleGraphicalObject(name + "_sph2",
                                                   "sphereMesh",
                                                   material,
                                                   {rad, rad, rad},
-                                                  {0, 0, -0.5},
+                                                  {0, 0, -0.5 * h},
                                                   rot,
                                                   0)});
 }


### PR DESCRIPTION
Hi, thanks for the great engine. Just a small issue that I found in the visualizer.

**Changes:**

* Added height into the offset used to place the
  bottom and top caps of the capsule w.r.t. its
  cylindrical part ( see [OgreVis.cpp](https://github.com/wpumacay/raisimOgre/blob/ae2ec4faf527e670720ed5bc85582853f977ba8b/src/OgreVis.cpp#L657) )

**Before:**

![img_capsules_not_ok](https://user-images.githubusercontent.com/26859929/70282746-cc612400-178c-11ea-87c4-62b01fc1dcb2.png)

**After:**

![img_capsules_ok](https://user-images.githubusercontent.com/26859929/70282749-cec37e00-178c-11ea-9568-bc80085a9248.png)


**Note:**

* There's an issue with mesh-scales which was fixed in devel ( #14 ) but hasn't been merged into master yet.