### PR TITLE
Singleton Redefinition Error at Link Time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(RAISIM_OGRE_EXAMPLES "Build example applications." FALSE)
 ####################################
 ########### dependencies ###########
 ####################################
-find_package(raisim 0.7.0 CONFIG REQUIRED)
+find_package(raisim CONFIG REQUIRED)
 find_package(OGRE 1.12.1 CONFIG REQUIRED COMPONENTS Bites RTShaderSystem)
 find_package(Eigen3 REQUIRED HINTS ${Eigen3_HINT})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(RAISIM_OGRE_EXAMPLES "Build example applications." FALSE)
 ####################################
 ########### dependencies ###########
 ####################################
-find_package(raisim 0.6.0 CONFIG REQUIRED)
+find_package(raisim 0.7.0 CONFIG REQUIRED)
 find_package(OGRE 1.12.1 CONFIG REQUIRED COMPONENTS Bites RTShaderSystem)
 find_package(Eigen3 REQUIRED HINTS ${Eigen3_HINT})
 

--- a/include/raisim/OgreVis.hpp
+++ b/include/raisim/OgreVis.hpp
@@ -339,7 +339,7 @@ private:
   OgreVis():
     ApplicationContext("RaiSim OGRE")
   {
-    RSINFO("Loading RaisimOgre Resources from: " + resourceDir_)
+    RSINFO("Loading RaiSim OGRE Resources from: " + std::string(OGREVIS_MAKE_STR(RAISIM_OGRE_RESOURCE_DIR)))
     RSINFO("Loading OGRE Configurations from: " + std::string(OGREVIS_MAKE_STR(OGRE_CONFIG_DIR)))
     resourceDir_ = std::string(OGREVIS_MAKE_STR(RAISIM_OGRE_RESOURCE_DIR));
     mFSLayer->setHomePath(std::string(OGREVIS_MAKE_STR(OGRE_CONFIG_DIR)));

--- a/include/raisim/OgreVis.hpp
+++ b/include/raisim/OgreVis.hpp
@@ -451,6 +451,4 @@ private:
 
 } // namespace raisim
 
-std::unique_ptr<raisim::OgreVis> raisim::OgreVis::singletonPtr(nullptr);
-
 #endif // RAISIM_OGRE_VIS_HPP

--- a/src/OgreVis.cpp
+++ b/src/OgreVis.cpp
@@ -1351,3 +1351,5 @@ void OgreVis::setAmbientLight(Ogre::ColourValue rgba) {
 }
 
 } // namespace raisim
+
+std::unique_ptr<raisim::OgreVis> raisim::OgreVis::singletonPtr(nullptr);


### PR DESCRIPTION
Moves initialization of static singleton pointer member to source file to resolve multiple re-definition errors at link-time.

Essentially, when multiple files include the `raisim/OgreVis.hpp` header, the initialization of the static member at the bottom of the file results in the aforementioned linking error. Moving that initialization to the `OgreVis.cpp` resolves the issue.

When users want to build a library that incorporates `OgreVis`, allowing multiple inclusions of the respective header must be permissible.