### PR TITLE
<build_depend>libogre</build_depend>

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
     <build_depend>sdl2</build_depend>
     <build_depend>zziplib</build_depend>
     <build_depend>zlib</build_depend>
+    <build_depend>libogre</build_depend>
     <!--Package Export-->
     <export>
         <build_type>cmake</build_type>


### PR DESCRIPTION
This should fix a missing dependency error in depending packages